### PR TITLE
Issue #2: Framework code lost on linking

### DIFF
--- a/lib/Koha/Contrib/Tamil/Authority/LinkBiblioTask.pm
+++ b/lib/Koha/Contrib/Tamil/Authority/LinkBiblioTask.pm
@@ -141,7 +141,9 @@ sub process {
         }
     }
     return 1 if !$self->doit || !$modified;
-    ModBiblio( $record, $self->reader->id );
+
+    my $framework_code = C4::Biblio::GetFrameworkCode( $self->reader->id );
+    ModBiblio( $record, $self->reader->id, $framework_code );
 
     return 1;
 }


### PR DESCRIPTION
All linked records are set to use the default framework because the
ModBiblio call is missing the framework_code param.

This patch adds it.

Signed-off-by: Tomas Cohen Arazi <tomascohen@theke.io>